### PR TITLE
Remove `console.log()` call

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ function flattenNodeGenerator(node, parent, index, settings, stack) {
 const flatten = function(tree, options) {
   let list = [];
   const stack = [];
-  console.log(tree);
   const _tree = _.cloneDeep(tree);
   const settings = {
     initNode: options.initNode || (node => node),


### PR DESCRIPTION
If the tree is large, this `console.log()` can litter your console, obstructing other useful feedback from your script.